### PR TITLE
l10n: Setup locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,8 +8,18 @@ i18n = import('i18n')
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (meson.project_name()), language:'c')
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
+
 executable(
     meson.project_name(),
+    config_file,
     'src/Application.vala',
     'src/MainWindow.vala',
     'src/IndividualView.vala',

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -33,6 +33,15 @@ public class Friends.Application : Gtk.Application {
         settings = new Settings ("io.elementary.friends");
     }
 
+    protected override void startup () {
+        base.startup ();
+
+        Intl.setlocale (LocaleCategory.ALL, "");
+        Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        Intl.textdomain (GETTEXT_PACKAGE);
+    }
+
     protected override void activate () {
         if (get_windows ().length () > 0) {
             get_windows ().data.present ();

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;


### PR DESCRIPTION
Towards #17

This is necessary so that the app is shown as translated on Flatpak:

<img width="819" height="657" alt="image" src="https://github.com/user-attachments/assets/1a5eb263-07e0-432b-a70b-345cfc07a89f" />
