### PR TITLE
folks: Use build-options instead of config-opts to force libdir

### DIFF
--- a/io.elementary.contacts.json
+++ b/io.elementary.contacts.json
@@ -114,9 +114,11 @@
                 "-Dofono_backend=false",
                 "-Dtelepathy_backend=false",
                 "-Dimport_tool=false",
-                "-Dinspect_tool=false",
-                "-Dlibdir=/app/lib"
+                "-Dinspect_tool=false"
             ],
+            "build-options": {
+                "libdir": "/app/lib"
+            },
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
Fixes the following build error:

    ERROR: Got argument libdir as both -Dlibdir and --libdir. Pick one.

https://github.com/elementary/contacts/actions/runs/28258844286/job/83728783434
