### PR TITLE
Flatpak: Port to libical v4

### DIFF
--- a/io.elementary.contacts.json
+++ b/io.elementary.contacts.json
@@ -81,11 +81,11 @@
                     "config-opts": [
                         "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
                         "-DCMAKE_INSTALL_LIBDIR=/app/lib",
-                        "-DWITH_CXX_BINDINGS=false",
-                        "-DSHARED_ONLY=true",
-                        "-DGOBJECT_INTROSPECTION=true",
-                        "-DICAL_BUILD_DOCS=false",
-                        "-DICAL_GLIB_VAPI=true",
+                        "-DLIBICAL_CXX_BINDINGS=false",
+                        "-DLIBICAL_JAVA_BINDINGS=false",
+                        "-DLIBICAL_GOBJECT_INTROSPECTION=true",
+                        "-DLIBICAL_BUILD_DOCS=false",
+                        "-DLIBICAL_GLIB_VAPI=true",
                         "-DLIBICAL_BUILD_TESTING=false"
                     ],
                     "sources": [

--- a/io.elementary.contacts.json
+++ b/io.elementary.contacts.json
@@ -49,14 +49,11 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/evolution-data-server.git",
-                    "tag": "3.56.2",
-                    "commit": "9330886fe4c5685bd18d1979bd5c60cb9c3fcc6d",
+                    "tag": "3.60.2",
+                    "commit": "c63344d7f4891503c108eda5faf50621ccb2602d",
                     "x-checker-data": {
                         "type": "git",
-                        "tag-pattern": "^([\\d.]+)$",
-                        "versions": {
-                            "<": "3.57"
-                        }
+                        "tag-pattern": "^(\\d+.\\d*[02468].\\d+)$"
                     }
                 }
             ],
@@ -95,8 +92,8 @@
                         {
                             "type": "git",
                             "url": "https://github.com/libical/libical.git",
-                            "tag": "v3.0.20",
-                            "commit": "57ce34025066935f356fd539e6deb7a7a9952618",
+                            "tag": "v4.0.3",
+                            "commit": "9b8163c78dfb43e8b700e6c7e531f0df64c208bf",
                             "x-checker-data": {
                                 "type": "git",
                                 "tag-pattern": "^v([\\d.]+)$"


### PR DESCRIPTION
Based on #48

## Changes Summary
- Update libical and evolution-data-server modules
  - libical: Update libical.git to 4.0.3
  - evolution-data-server: Update evolution-data-server.git to 3.60.2
- libical: Follow CMake options changes
  - See https://github.com/libical/libical/blob/4.0/docs/MigrationGuide_to_4.md
